### PR TITLE
Upgrade Go to 1.26.2 and Debian to 13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM golang:1.25-trixie AS builder
+FROM golang:1.26.2-trixie AS builder
 
 RUN mkdir /build
 
@@ -12,7 +12,7 @@ ADD . ./
 RUN go build -v -o /build/ ./cmd/*
 
 # Stage 2: Copy files and configure what we need
-FROM debian:bullseye-slim
+FROM debian:13.4-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seabird-chat/seabird-nwwsio-plugin
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/joho/godotenv v1.5.1
@@ -8,6 +8,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/seabird-chat/seabird-go v0.6.1
 	golang.org/x/sync v0.18.0
+	google.golang.org/grpc v1.71.1
 	gosrc.io/xmpp v0.5.1
 )
 
@@ -19,7 +20,6 @@ require (
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250409194420-de1ac958c67a // indirect
-	google.golang.org/grpc v1.71.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	nhooyr.io/websocket v1.8.17 // indirect
 )


### PR DESCRIPTION
Bumps the builder to `golang:1.26.2-trixie`, the runtime to `debian:13.4-slim`, and the `go` directive to 1.26.2.